### PR TITLE
Add Arrow --add-opens to pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
                 <version>3.2.5</version>
+                <configuration>
+                    <argLine>--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Arrow requires some JDK internals to be exposed using
```
--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
```

This PR lets avoid setting this options manually (e.g. when running tests using Intellij IDEA GUI).