### PR TITLE
Fix TestTask3

### DIFF
--- a/src/test/java/com/querifylabs/dbcourse/rel/TestTask3.java
+++ b/src/test/java/com/querifylabs/dbcourse/rel/TestTask3.java
@@ -64,10 +64,10 @@ public class TestTask3 extends TestBase {
         var filter = (LogicalFilter)optimized.getInput(0);
 
         assertThat(project.getProjects()).hasSize(3);
-        assertThat(project.getProjects().get(0).toString()).isEqualTo("base64decode($0)");
+        assertThat(project.getProjects().get(0).toString()).isEqualTo("base64decode($6)");
         assertThat(project.getProjects().get(1).toString()).isEqualTo("X'41':BINARY(1)");
         assertThat(project.getProjects().get(2).toString()).isEqualTo("||('A', CAST(X'41':BINARY(1)):VARCHAR NOT NULL)");
 
-        assertThat(filter.getCondition().toString()).isEqualTo("=(CAST($0):VARBINARY, X'41':BINARY(1))");
+        assertThat(filter.getCondition().toString()).isEqualTo("=(CAST($6):VARBINARY, X'41':BINARY(1))");
     }
 }

--- a/src/test/java/com/querifylabs/dbcourse/rel/TestTask3.java
+++ b/src/test/java/com/querifylabs/dbcourse/rel/TestTask3.java
@@ -64,10 +64,10 @@ public class TestTask3 extends TestBase {
         var filter = (LogicalFilter)optimized.getInput(0);
 
         assertThat(project.getProjects()).hasSize(3);
-        assertThat(project.getProjects().get(0).toString()).isEqualTo("base64decode($6)");
+        assertThat(project.getProjects().get(0).toString()).matches("base64decode\\(\\$[06]\\)");
         assertThat(project.getProjects().get(1).toString()).isEqualTo("X'41':BINARY(1)");
         assertThat(project.getProjects().get(2).toString()).isEqualTo("||('A', CAST(X'41':BINARY(1)):VARCHAR NOT NULL)");
 
-        assertThat(filter.getCondition().toString()).isEqualTo("=(CAST($6):VARBINARY, X'41':BINARY(1))");
+        assertThat(filter.getCondition().toString()).matches("=\\(CAST\\(\\$([06])\\):VARBINARY, X'41':BINARY\\(1\\)\\)");
     }
 }


### PR DESCRIPTION
Поле `store_and_fwd_flag` становится нулевым по счету только после выполнения четвертого задания (где добавится проекция сразу после сканирования). Без `trimUnusedFields` план исполнения запроса выглядит следующим образом:
```
LogicalProject(EXPR$0=[base64decode($6)], EXPR$1=[base64decode('QQ==')], EXPR$2=[||('A', CAST(base64decode('QQ==')):VARCHAR NOT NULL)])
  LogicalFilter(condition=[=(CAST($6):VARBINARY, base64decode('QQ=='))])
    LogicalTableScan(table=[[public, taxirides]])
```

Таким образом, `store_and_fwd_flag` может быть как 6-м, так и 0-м по счету в зависимости от выполнения 4-го задания.